### PR TITLE
Fix handling of missing sampler in command line args

### DIFF
--- a/omnisolver/cmd.py
+++ b/omnisolver/cmd.py
@@ -44,6 +44,11 @@ def main():
 
     args = root_parser.parse_args()
 
+    if not hasattr(args, "sample"):
+        print("Missing argument. You need to supply solver name.")
+        root_parser.print_usage()
+        exit(1)
+
     result = args.sample(args)
 
     result.to_pandas_dataframe().to_csv(args.output)


### PR DESCRIPTION
This fixes a crash that occurs if no sampler is specified in command-line arguments.

To test:
- reinstall the package
- run `omnisolver` without arguments.

Expected result: following should be printed to stdout:
- an error message describing that sampler needs to be specified
- a shortened usage of `omnisolver` script
In addition, the script should return with a nonzero exit code.
