### PR TITLE
Feature/serialization

### DIFF
--- a/omnisolver/adapters.py
+++ b/omnisolver/adapters.py
@@ -4,6 +4,8 @@ import importlib
 import dimod
 from typing_extensions import Protocol
 
+from omnisolver.serialization import bqm_from_coo
+
 
 class Adapter(Protocol):
     def __init__(self) -> None:
@@ -98,7 +100,6 @@ class SimpleAdapter:
             arg_spec["name"]: getattr(cmd_args, arg_spec["name"])
             for arg_spec in self.sample_args_spec
         }
-        bqm = dimod.BinaryQuadraticModel.from_coo(
-            cmd_args.input, vartype=cmd_args.vartype
-        )
+
+        bqm = bqm_from_coo(cmd_args.input, vartype=cmd_args.vartype)
         return sampler.sample(bqm, **kwargs)

--- a/omnisolver/serialization.py
+++ b/omnisolver/serialization.py
@@ -1,0 +1,23 @@
+"""Tools for serializing and deserializing BQms."""
+from typing import Union, TextIO
+from os import PathLike
+from dimod import BQM
+import pandas as pd
+
+
+def bqm_from_coo(coo: Union[PathLike, TextIO], vartype="BINARY") -> BQM:
+    """Read bqm from coordinate format.
+
+    This is intended as a replacement for dimod.serialization.coo.load,
+    which sometimes handles integral coefficients poorly.
+    """
+    df = pd.read_csv(coo, names=["i", "j", "coefficient"], sep=" ")
+    quadratic = {}
+    linear = {}
+    print(df.values.tolist())
+    for i, j, coefficient in df.itertuples(index=False):
+        if i == j:
+            linear[i] = coefficient
+        else:
+            quadratic[(i, j)] = coefficient
+    return BQM(linear, quadratic, vartype=vartype)

--- a/omnisolver/tests/test_serialization.py
+++ b/omnisolver/tests/test_serialization.py
@@ -1,0 +1,47 @@
+"""Test cases for omnisolver.serialization."""
+from textwrap import dedent
+from typing import Any, Dict
+from dimod import vartypes
+import pytest
+from io import StringIO
+from omnisolver.serialization import bqm_from_coo
+
+
+def make_coo(string):
+    return StringIO(dedent(string).strip("\n"))
+
+
+def sorted_quadratic(quadratic: Dict[Any, float]):
+    return {tuple(sorted(k)): v for k, v in quadratic.items()}
+
+
+@pytest.mark.parametrize("vartype", ["SPIN", "BINARY"])
+def test_sets_correct_vartype(vartype):
+    """BQM loaded from coo should have correct vartype."""
+    coo = make_coo(
+        """0 1 2.5
+        1 1 -3
+        2 0 4
+        4 3 -1.2
+        0 3 0.1123456
+        """
+    )
+    bqm = bqm_from_coo(coo, vartype=vartype)
+    assert bqm.vartype == vartypes.as_vartype(vartype)
+
+
+@pytest.mark.parametrize("vartype", ["SPIN", "BINARY"])
+def test_sets_correct_coefficients(vartype):
+    """BQM loaded from coo should have correct coefficients"""
+    coo = make_coo(
+        """
+        0 1 2.5
+        1 1 -3
+        0 2 4
+        3 4 -1.2
+        3 3 0.03125
+        """
+    )
+    bqm = bqm_from_coo(coo, vartype=vartype)
+    assert bqm.linear == {1: -3, 3: 0.03125, 0: 0, 2: 0, 4: 0}
+    assert sorted_quadratic(bqm.quadratic) == {(0, 2): 4, (3, 4): -1.2, (0, 1): 2.5}


### PR DESCRIPTION
This adds support for reading BQM from coordinate (COO) format. It is meant as a replacement for the dimod's `coo.load`.

How to test:
- Consider this input file:
```
0 0 0
0 1 1
2 3 0
4 5 6
```
- Solve it using the version from master, i.e. using `omnisolver random --input in.txt`
- The solution should be empty because of bug in dimod's deserialization.
- Reinstall omnisolver from this branch.
- Rerun the example. It should give a meaningful output with 7 variables labelled 0-7.